### PR TITLE
move scripts/web/GitHubApi.py to scripts/lib/GitHubApi.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+#lib/
 lib64/
 parts/
 sdist/

--- a/scripts/lib/GithubApi.py
+++ b/scripts/lib/GithubApi.py
@@ -85,7 +85,7 @@ class GithubApi:
 		
 		# workflow_idを用いて、dispatch_eventを発生させる(github actionsを実行)
 		data={}
-		data["ref"]="develop"
+		data["ref"]="main"
 		data["inputs"]={"artifact_name": self.work_id}
 		status_workflow_dispatch=requests.post(base_url+"/"+str(workflows_id)+"/dispatches", headers=headers, auth=HTTPBasicAuth(self.github_user, self.github_token),data=json.dumps(data))
 		

--- a/scripts/lib/GithubApi.py
+++ b/scripts/lib/GithubApi.py
@@ -85,7 +85,7 @@ class GithubApi:
 		
 		# workflow_idを用いて、dispatch_eventを発生させる(github actionsを実行)
 		data={}
-		data["ref"]="main"
+		data["ref"]="develop"
 		data["inputs"]={"artifact_name": self.work_id}
 		status_workflow_dispatch=requests.post(base_url+"/"+str(workflows_id)+"/dispatches", headers=headers, auth=HTTPBasicAuth(self.github_user, self.github_token),data=json.dumps(data))
 		

--- a/scripts/web/outside_main.py
+++ b/scripts/web/outside_main.py
@@ -4,6 +4,7 @@ import json
 import zipfile
 import tempfile
 import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
 import GithubApi
 
 def main():


### PR DESCRIPTION
GitHubApi.pyをscripts/web/から/scripts/libに移動
移動に伴うlibディレクトリの作成およびoutside_main.pyの変更