### PR TITLE
dns_outside.actions.pyのバグの修正

### DIFF
--- a/scripts/dns/dns_outside.actions.py
+++ b/scripts/dns/dns_outside.actions.py
@@ -38,11 +38,11 @@ if __name__ == '__main__':
         if host['method'] == 'default':
             if "addr" not in host:
                 host["addr"]=""
-                dnslookup(host, result, i)
+            dnslookup(host, result, i)
         else:
             if "domain" not in host:
                 host["domain"]=""
-                reverse_dnslookup(host, result, i)
+            reverse_dnslookup(host, result, i)
         i += 1
             
     with open('result.txt', 'w') as result_file:


### PR DESCRIPTION
外側からの全てのテストにおいて`dnslookup`関数と`reverse_dnslookup`関数が呼びだされずテストが成功となるバグを修正しました．